### PR TITLE
initial commit

### DIFF
--- a/Magento_Theme/layout/cms_index_index.xml
+++ b/Magento_Theme/layout/cms_index_index.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="critical_css_block">
+            <arguments>
+                <argument name="pageType" xsi:type="string">home</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/Magento_Theme/templates/html/header/criticalCss.phtml
+++ b/Magento_Theme/templates/html/header/criticalCss.phtml
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @var \Magento\Theme\Block\Html\Header\CriticalCss $criticalCssViewModel
+ */
+?>
+<?php 
+$criticalCssViewModel = $block->getData('criticalCssViewModel'); 
+$pageType = $block->getData('pageType');
+
+$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+$pageLayouts = $objectManager->get(\Magento\Framework\App\View::class);
+
+$pageHandle1 = $pageLayouts->getLayout()->getUpdate()->getHandles()[1];
+$pageHandle2 = $pageLayouts->getLayout()->getUpdate()->getHandles()[2];
+$pageHandle3 = $pageLayouts->getLayout()->getUpdate()->getHandles()[3];
+?>
+
+<?php if ($pageType): ?>
+    <style type="text/css" data-page="<?= $pageHandle1 . ' ' . $pageHandle2 . ' ' . $pageHandle3 ?>" data-type="criticalCss">
+        <?= $criticalCssViewModel->getCriticalCssData(); ?>
+        <?= $block->getLayout()
+        ->createBlock('Magento\Cms\Block\Block')
+        ->setBlockId($pageType . '-criticalCss')
+        ->toHtml(); ?>
+    </style>
+<?php else: ?>
+    <style type="text/css" data-page="<?= $pageHandle1 . ' ' . $pageHandle2 . ' ' . $pageHandle3 ?>" data-type="criticalCss">
+        <?= $criticalCssViewModel->getCriticalCssData(); ?>
+    </style>
+<?php endif; ?>

--- a/web/css/critical.css
+++ b/web/css/critical.css
@@ -1,0 +1,3 @@
+body {
+    background-color: blueviolet !important;
+}


### PR DESCRIPTION
Add layout instructions for cms_index_index adding an argument named pageType to pass to the criticalCss.phtml 
Add template logic to check for pageType data from the layout instructions and if so render static block with ID = home-criticalCss 
If no, specific static block exists or no specific layout instruction is passed to template, then standard criticalCss is rendered 
Includes data-page attribute to display page handles in html, so specific layout instructions can be easily referenced and created